### PR TITLE
Amend Dockerfile to support alternative base images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ name: CI
       - master
   repository_dispatch:
     types: [lib-update]
+  workflow_dispatch:
 jobs:
   lint-dockerfile:
     name: Lint Dockerfile
@@ -17,10 +18,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Hadolint Dockerfile Linter
         uses: burdzwastaken/hadolint-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HADOLINT_ACTION_DOCKERFILE_FOLDER: docker
-
+        with:
+          dockerfile: extras/docker
+          ignore: DL3006 DL3008 DL3033 
   lint-markdown:
     name: Lint Markdown
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Hadolint Dockerfile Linter
         uses: burdzwastaken/hadolint-action@master
-        with:
-          dockerfile: docker
-          ignore: DL3006 DL3008 DL3033 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HADOLINT_ACTION_DOCKERFILE_FOLDER: docker
   lint-markdown:
     name: Lint Markdown
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run Hadolint Dockerfile Linter
         uses: burdzwastaken/hadolint-action@master
         with:
-          dockerfile: extras/docker
+          dockerfile: docker
           ignore: DL3006 DL3008 DL3033 
   lint-markdown:
     name: Lint Markdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
       - name: Run Hadolint Dockerfile Linter
-        uses: burdzwastaken/hadolint-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HADOLINT_ACTION_DOCKERFILE_FOLDER: docker
+        uses: hadolint/hadolint-action@master
+        with:
+          dockerfile: docker/Dockerfile
+          ignore: DL3006 DL3008 DL3033
   lint-markdown:
     name: Lint Markdown
     runs-on: ubuntu-latest

--- a/docker/.hadolint.yaml
+++ b/docker/.hadolint.yaml
@@ -1,0 +1,1 @@
+.hadolint.yaml

--- a/docker/.hadolint.yaml
+++ b/docker/.hadolint.yaml
@@ -1,1 +1,4 @@
-.hadolint.yaml
+ignored:
+  - DL3006
+  - DL3008
+  - DL3033

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,15 @@
-ARG NODE_VERSION=12
+ARG NODE_VERSION=14
 ARG GITHUB_ACCOUNT=FIWARE
 ARG GITHUB_REPOSITORY=iotagent-isoxml
 ARG DOWNLOAD=latest
 ARG SOURCE_BRANCH=master
+
+# Default Builder, distro and distroless build version
+ARG BUILDER=node:${NODE_VERSION}
+ARG DISTRO=node:${NODE_VERSION}-slim
+ARG DISTROLESS=gcr.io/distroless/nodejs:${NODE_VERSION}
+ARG PACKAGE_MANAGER=apt
+ARG USER=node
 
 ########################################################################################
 #
@@ -21,11 +28,12 @@ ARG SOURCE_BRANCH=master
 # --target=builder
 #
 ######################################################################################## 
-FROM node:${NODE_VERSION} AS builder
+FROM ${BUILDER} AS builder
 ARG GITHUB_ACCOUNT
 ARG GITHUB_REPOSITORY
 ARG DOWNLOAD
 ARG SOURCE_BRANCH
+ARG PACKAGE_MANAGER
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -36,10 +44,25 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # COPY . /opt/iotISOXML/
 #
 
+# hadolint ignore=DL3002
+USER root
+RUN \
+	# Ensure that the chosen package manger is supported by this Dockerfile
+	# also ensure that unzip is installed prior to downloading sources
+	if [ "${PACKAGE_MANAGER}" = "apt"  ]; then \
+		echo -e "\033[0;34mINFO: Using default \"${PACKAGE_MANAGER}\".\033[0m"; \
+		apt-get install -y --no-install-recommends unzip git; \
+	elif [ "${PACKAGE_MANAGER}" = "yum"  ]; then \
+		echo -e "\033[0;33mWARNING: Overriding default package manager. Using \"${PACKAGE_MANAGER}\" .\033[0m"; \
+		yum install -y unzip git; \
+		yum clean all; \
+	else \
+	 	echo -e "\033[0;31mERROR: Package Manager \"${PACKAGE_MANAGER}\" not supported.\033[0m"; \
+	 	exit 1; \
+	fi
+
 # hadolint ignore=DL3008
 RUN \
-	# Ensure that unzip is installed prior to downloading
-	apt-get install -y --no-install-recommends unzip && \
 	if [ "${DOWNLOAD}" = "latest" ] ; \
 	then \
 		RELEASE="${SOURCE_BRANCH}"; \
@@ -56,25 +79,13 @@ RUN \
 	curl -s -L https://github.com/"${GITHUB_ACCOUNT}"/"${GITHUB_REPOSITORY}"/archive/"${RELEASE}".zip > source.zip && \
 	unzip source.zip -x "*/test/**" "*/rpm/**" "*/ghpages/**" "*/docs/**" "*/.*" && \
 	rm source.zip && \
-	mv "${GITHUB_REPOSITORY}-${RELEASE_CONCAT}" /opt/iotISOXML && \
-	# Remove unzip and clean apt cache
-	apt-get clean && \
-	apt-get remove -y unzip && \
-	apt-get -y autoremove && \
-	rm -rf /var/lib/apt/lists/* 
+	mv "${GITHUB_REPOSITORY}-${RELEASE_CONCAT}" /opt/iotISOXML
 
 WORKDIR /opt/iotISOXML
 
-# hadolint ignore=DL3008
 RUN \
-	# Ensure that Git is installed prior to running npm install
-	apt-get install -y --no-install-recommends git && \
 	echo "INFO: npm install --production..." && \
-	npm install --only=prod --no-package-lock --no-optional && \
-	# Remove Git and clean apt cache
-	apt-get clean && \
-	apt-get remove -y git && \
-	apt-get -y autoremove
+	npm install --only=prod --no-package-lock --no-optional
 
 ########################################################################################
 #
@@ -85,10 +96,11 @@ RUN \
 # --target=pm2-install
 #
 ########################################################################################
-FROM node:${NODE_VERSION}-slim AS pm2
+FROM ${DISTRO} AS pm2
 ARG GITHUB_ACCOUNT
 ARG GITHUB_REPOSITORY
 ARG NODE_VERSION
+ARG USER
 
 LABEL "maintainer"="FIWARE Foundation e.V."
 LABEL "org.opencontainers.image.authors"=""
@@ -103,7 +115,7 @@ LABEL "org.nodejs.version"="${NODE_VERSION}"
 COPY --from=builder /opt/iotISOXML /opt/iotISOXML
 RUN npm install pm2@4.4.0 -g --no-package-lock --no-optional
 
-USER node
+USER ${USER}
 ENV NODE_ENV=production
 # Expose 4041 for NORTH PORT, 7896 for HTTP PORT
 EXPOSE ${IOTA_NORTH_PORT:-4041} ${IOTA_HTTP_PORT:-7896}
@@ -116,7 +128,9 @@ HEALTHCHECK NONE
 # as defined below.
 #
 ########################################################################################
-FROM node:${NODE_VERSION}-slim AS anon-user
+FROM ${DISTRO} AS anon-user
+# hadolint ignore=DL3002
+USER root
 RUN sed -i -r "/^(root|nobody)/!d" /etc/passwd /etc/shadow /etc/group \
     && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
 
@@ -132,7 +146,7 @@ RUN sed -i -r "/^(root|nobody)/!d" /etc/passwd /etc/shadow /etc/group \
 # - IOTA_AUTH_CLIENT_ID, IOTA_AUTH_CLIENT_SECRET - when using OAuth2 Security
 #
 ########################################################################################
-FROM gcr.io/distroless/nodejs:${NODE_VERSION} AS distroless
+FROM ${DISTROLESS} AS distroless
 ARG GITHUB_ACCOUNT
 ARG GITHUB_REPOSITORY
 ARG NODE_VERSION
@@ -171,10 +185,11 @@ HEALTHCHECK  --interval=30s --timeout=3s --start-period=10s \
 # - IOTA_AUTH_CLIENT_ID, IOTA_AUTH_CLIENT_SECRET - when using OAuth2 Security
 #
 ########################################################################################
-FROM node:${NODE_VERSION}-slim AS slim
+FROM ${DISTRO} AS slim
 ARG GITHUB_ACCOUNT
 ARG GITHUB_REPOSITORY
 ARG NODE_VERSION
+ARG USER
 
 LABEL "maintainer"="FIWARE Foundation e.V."
 LABEL "org.opencontainers.image.authors"=""
@@ -189,7 +204,7 @@ LABEL "org.nodejs.version"="${NODE_VERSION}"
 COPY --from=builder /opt/iotISOXML /opt/iotISOXML
 WORKDIR /opt/iotISOXML
 
-USER node
+USER ${USER}
 ENV NODE_ENV=production
 # Expose 4041 for NORTH PORT, 7896 for HTTP PORT
 EXPOSE ${IOTA_NORTH_PORT:-4041} ${IOTA_HTTP_PORT:-7896}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,15 +37,9 @@ ARG PACKAGE_MANAGER
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# As an Alternative for local development, just copy this Dockerfile into file the root of 
-# the repository and replace the whole RUN statement below by the following COPY statement 
-# in your local source using :
-#
-# COPY . /opt/iotISOXML/
-#
-
 # hadolint ignore=DL3002
 USER root
+# hadolint ignore=DL3059
 RUN \
 	# Ensure that the chosen package manger is supported by this Dockerfile
 	# also ensure that unzip is installed prior to downloading sources
@@ -61,6 +55,12 @@ RUN \
 	 	exit 1; \
 	fi
 
+# As an Alternative for local development, just copy this Dockerfile into file the root of 
+# the repository and replace the whole RUN statement below by the following COPY statement 
+# in your local source using :
+#
+# COPY . /opt/iotISOXML/
+#
 # hadolint ignore=DL3008
 RUN \
 	if [ "${DOWNLOAD}" = "latest" ] ; \

--- a/docker/README.md
+++ b/docker/README.md
@@ -203,6 +203,39 @@ Manager by using the associated `distroless` Image.
 docker run --name iotagent -d fiware/iotagent-isoxml-distroless
 ```
 
+
+## Building using an alternative sources and Linux Distros
+
+The `Dockerfile` is flexible enough to be able to use
+[alternative base images](https://kuberty.io/blog/best-os-for-docker/) should you wish. The base image defaults to using
+the `node:slim` distro, but other base images can be injected using `--build-arg` parameters on the commmand line. For
+example, to create a container based on
+[Red Hat UBI (Universal Base Image) 8](https://developers.redhat.com/articles/2021/11/08/optimize-nodejs-images-ubi-8-nodejs-minimal-image)
+add `BUILDER`, `DISTRO`, `PACKAGE_MANAGER` and `USER` parameters as shown:
+
+```console
+docker build -t iot-agent \
+  --build-arg BUILDER=registry.access.redhat.com/ubi8/nodejs-14 \
+  --build-arg DISTRO=registry.access.redhat.com/ubi8/nodejs-14-minimal \
+  --build-arg PACKAGE_MANAGER=yum \
+  --build-arg USER=1001 . --no-cache
+```
+
+Currently, the following `--build-arg` parameters are supported:
+
+| Parameter           | Description                                                                                                                                                                                                                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BUILDER`           | Preferred [linux distro](https://kuberty.io/blog/best-os-for-docker/) to use whilst building the image, defaults to `node:${NODE_VERSION}`                                                                                                                                              |
+| `DISTRO`            | Preferred [linux distro](https://kuberty.io/blog/best-os-for-docker/) to use for the final container image, defaults to `node:${NODE_VERSION}-slim`                                                                                                                                     |
+| `DISTROLESS`        | Preferred [Distroless Image](https://betterprogramming.pub/how-to-harden-your-containers-with-distroless-docker-images-c2abd7c71fdb) to use for the final container. Distroless images can be built using `-target=distroless` , defaults to `gcr.io/distroless/nodejs:${NODE_VERSION}` |
+| `DOWNLOAD`          | The GitHub SHA or tag to download - defaults to `latest`                                                                                                                                                                                                                                |
+| `GITHUB_ACCOUNT`    | The GitHub Action to download the source files from, defaults to `ging`                                                                                                                                                                                                                 |
+| `GITHUB_REPOSITORY` | The name of the GitHub repository to download the source files from, defaults to `fiware-pep-proxy`                                                                                                                                                                                     |
+| `NODE_VERSION`      | the version of Node.js to use                                                                                                                                                                                                                                                           |
+| `PACKAGE_MANAGER`   | Package manager to use whilst creating the build, defaults to `apt`                                                                                                                                                                                                                     |
+| `SOURCE_BRANCH`     | The GitHub repository branch to download the source files from, defaults to `master`                                                                                                                                                                                                    |
+| `USER`              | User in the final container image, defaults to `node`                                                                                                                                                                                                                                   |
+
 ### Docker Secrets
 
 As an alternative to passing sensitive information via environment variables, `_FILE` may be appended to some sensitive


### PR DESCRIPTION
## Proposed changes

This PR updates the `Dockerfile` so it is flexible enough to be able to use [alternative base images](https://kuberty.io/blog/best-os-for-docker/) should you wish. The base image still defaults  to using the `node:slim` distro, but other base images can be injected using `--build-arg` parameters on the command line. For example, to create a container based on [Red Hat UBI (Universal Base Image) 8](https://developers.redhat.com/articles/2021/11/08/optimize-nodejs-images-ubi-8-nodejs-minimal-image)
add `BUILDER`, `DISTRO`, `PACKAGE_MANAGER` and `USER` parameters as shown:

```console
sudo docker build -t iot-agent \
  --build-arg BUILDER=registry.access.redhat.com/ubi8/nodejs-14 \
  --build-arg DISTRO=registry.access.redhat.com/ubi8/nodejs-14-minimal \
  --build-arg PACKAGE_MANAGER=yum \
  --build-arg USER=1001 .
```

This allows users to upgrade to **their preferred Linux distro** and helps to reduces Critical Vulnerabilities, and therefore makes the final product more secure.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [x] I have read the [CONTRIBUTING](https://github.com/ging/fiware-pep-proxy/blob/master/CONTRIBUTING.md) doc
-   [x] I have signed the [CLA](https://github.com/ging/fiware-pep-proxy/blob/master/wilma-individual-cla.pdf)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

At the moment the base image is still `node-slim`. You may wish to alter this at some point by amending the default build args. Hadolint complains that the images are no longer pinned to versions but this is a false positive as the builder is now under control of the version to use and could even supply the appropriate SHA if they wish.
